### PR TITLE
Using assertSame to make equals assertion

### DIFF
--- a/tests/StreamDecorators/Base64StreamTest.php
+++ b/tests/StreamDecorators/Base64StreamTest.php
@@ -100,9 +100,7 @@ class Base64StreamTest extends TestCase
         $handle = StreamWrapper::getResource($streamDecorator);
 
         $horg = fopen($org, 'r');
-        $this->assertTrue(
-            stream_get_contents($handle) === stream_get_contents($horg)
-        );
+        $this->assertSame(stream_get_contents($horg), stream_get_contents($handle));
 
         fclose($horg);
         fclose($handle);

--- a/tests/StreamDecorators/CharsetStreamTest.php
+++ b/tests/StreamDecorators/CharsetStreamTest.php
@@ -17,7 +17,7 @@ class CharsetStreamTest extends TestCase
 {
     private $converter;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->converter = new MbWrapper();


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make streaming contents are same.
- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html?highlight=fixtures), it should be the `protected function setUp`.