### PR TITLE
Fix PHP 8.1 return type deprecation notices.

### DIFF
--- a/src/Base64Stream.php
+++ b/src/Base64Stream.php
@@ -209,6 +209,7 @@ class Base64Stream implements StreamInterface
     /**
      * Closes the underlying stream after writing out any remaining bytes
      * needing to be encoded.
+     * @return void
      */
     public function close()
     {
@@ -219,6 +220,7 @@ class Base64Stream implements StreamInterface
     /**
      * Detaches the underlying stream after writing out any remaining bytes
      * needing to be encoded.
+     * @return resource|null Underlying PHP stream, if any
      */
     public function detach()
     {

--- a/src/ChunkSplitStream.php
+++ b/src/ChunkSplitStream.php
@@ -104,6 +104,7 @@ class ChunkSplitStream implements StreamInterface
     /**
      * Closes the stream after ensuring a final line ending character is
      * inserted.
+     * @return void
      */
     public function close()
     {
@@ -114,6 +115,7 @@ class ChunkSplitStream implements StreamInterface
     /**
      * Detaches the stream after ensuring a final line ending character is
      * inserted.
+     * @return resource|null Underlying PHP stream, if any
      */
     public function detach()
     {

--- a/src/NonClosingStream.php
+++ b/src/NonClosingStream.php
@@ -41,6 +41,7 @@ class NonClosingStream implements StreamInterface
 
     /**
      * Overridden to detach the underlying stream without closing it.
+     * @return void
      */
     public function close()
     {
@@ -49,6 +50,7 @@ class NonClosingStream implements StreamInterface
 
     /**
      * Overridden to detach the underlying stream without closing it.
+     * @return resource|null Underlying PHP stream, if any
      */
     public function detach()
     {

--- a/src/QuotedPrintableStream.php
+++ b/src/QuotedPrintableStream.php
@@ -211,6 +211,7 @@ class QuotedPrintableStream implements StreamInterface
     /**
      * Closes the underlying stream and writes a final CRLF if the current line
      * isn't empty.
+     * @return void
      */
     public function close()
     {
@@ -221,6 +222,7 @@ class QuotedPrintableStream implements StreamInterface
     /**
      * Closes the underlying stream and writes a final CRLF if the current line
      * isn't empty.
+     * @return resource|null Underlying PHP stream, if any
      */
     public function detach()
     {

--- a/src/UUStream.php
+++ b/src/UUStream.php
@@ -311,6 +311,7 @@ class UUStream implements StreamInterface
     /**
      * Writes any remaining bytes out followed by the uu-encoded footer, then
      * closes the stream.
+     * @return void
      */
     public function close()
     {
@@ -321,6 +322,7 @@ class UUStream implements StreamInterface
     /**
      * Writes any remaining bytes out followed by the uu-encoded footer, then
      * detaches the stream.
+     * @return resource|null Underlying PHP stream, if any
      */
     public function detach()
     {


### PR DESCRIPTION
Fix deprecation notices like:
`Method "Psr\Http\Message\StreamInterface::close()" might add "void" as a native return type declaration in the future. Do the same in implementation "ZBateson\StreamDecorators\NonClosingStream" now to avoid errors or add an explicit @return annotation to suppress this message.`