### PR TITLE
Modernize to PHP 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5, 5.4]
+        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require zbateson/stream-decorators
 
 ## Requirements
 
-StreamDecorators requires PHP 5.4 or newer.  Tested on PHP 5.4, 5.5, 5.6, 7, 7.1, 7.2, 7.3, 7.4 and 8.0.
+StreamDecorators requires PHP 7.1 or newer.  Tested on PHP 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,14 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "guzzlehttp/psr7": "^1.7.0|^2.0",
+        "php": ">=7.1",
+        "guzzlehttp/psr7": "^1.9 | ^2.0",
         "zbateson/mb-wrapper": "^1.0.0"
     },
     "require-dev": {
-        "sanmai/phpunit-legacy-adapter": "^6.3 || ^8"
+        "phpunit/phpunit": "<=9.0",
+        "friendsofphp/php-cs-fixer": "*",
+        "phpstan/phpstan": "*"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+parameters:
+	level: 6
+	errorFormat: raw
+	editorUrl: '%%file%% %%line%% %%column%%: %%error%%'
+	paths:
+		- src
+		- tests
+	ignoreErrors:
+		-
+			message: '#::seek\(\) has no return type specified.#'
+			paths:
+				- src/*
+

--- a/src/ChunkSplitStream.php
+++ b/src/ChunkSplitStream.php
@@ -4,10 +4,11 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\StreamDecorators;
 
-use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Inserts line ending characters after the set number of characters have been
@@ -46,40 +47,32 @@ class ChunkSplitStream implements StreamInterface
      */
     private $stream;
 
-    /**
-     * @param StreamInterface $stream
-     * @param int $lineLength
-     * @param string $lineEnding
-     */
-    public function __construct(StreamInterface $stream, $lineLength = 76, $lineEnding = "\r\n")
+    public function __construct(StreamInterface $stream, int $lineLength = 76, string $lineEnding = "\r\n")
     {
         $this->stream = $stream;
         $this->lineLength = $lineLength;
         $this->lineEnding = $lineEnding;
-        $this->lineEndingLength = strlen($this->lineEnding);
+        $this->lineEndingLength = \strlen($this->lineEnding);
     }
 
     /**
      * Inserts the line ending character after each line length characters in
      * the passed string, making sure previously written bytes are taken into
      * account.
-     *
-     * @param string $string
-     * @return string
      */
-    private function getChunkedString($string)
+    private function getChunkedString(string $string) : string
     {
         $firstLine = '';
         if ($this->tell() !== 0) {
             $next = $this->lineLength - ($this->position % ($this->lineLength + $this->lineEndingLength));
-            if (strlen($string) > $next) {
-                $firstLine = substr($string, 0, $next) . $this->lineEnding;
-                $string = substr($string, $next);
+            if (\strlen($string) > $next) {
+                $firstLine = \substr($string, 0, $next) . $this->lineEnding;
+                $string = \substr($string, $next);
             }
         }
         // chunk_split always ends with the passed line ending
-        $chunked = $firstLine . chunk_split($string, $this->lineLength, $this->lineEnding);
-        return substr($chunked, 0, strlen($chunked) - $this->lineEndingLength);
+        $chunked = $firstLine . \chunk_split($string, $this->lineLength, $this->lineEnding);
+        return \substr($chunked, 0, \strlen($chunked) - $this->lineEndingLength);
     }
 
     /**
@@ -89,17 +82,17 @@ class ChunkSplitStream implements StreamInterface
      * @param string $string
      * @return int number of bytes written
      */
-    public function write($string)
+    public function write($string) : int
     {
         $chunked = $this->getChunkedString($string);
-        $this->position += strlen($chunked);
+        $this->position += \strlen($chunked);
         return $this->stream->write($chunked);
     }
 
     /**
      * Inserts a final line ending character.
      */
-    private function beforeClose()
+    private function beforeClose() : void
     {
         if ($this->position !== 0) {
             $this->stream->write($this->lineEnding);
@@ -107,24 +100,22 @@ class ChunkSplitStream implements StreamInterface
     }
 
     /**
-     * Closes the stream after ensuring a final line ending character is
-     * inserted.
-     * @return void
+     * @inheritDoc
      */
-    public function close()
+    public function close() : void
     {
         $this->beforeClose();
         $this->stream->close();
     }
 
     /**
-     * Detaches the stream after ensuring a final line ending character is
-     * inserted.
-     * @return resource|null Underlying PHP stream, if any
+     * @inheritDoc
      */
     public function detach()
     {
         $this->beforeClose();
         $this->stream->detach();
+
+        return null;
     }
 }

--- a/src/NonClosingStream.php
+++ b/src/NonClosingStream.php
@@ -4,10 +4,11 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\StreamDecorators;
 
-use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Doesn't close the underlying stream when 'close' is called on it.  Instead,
@@ -40,25 +41,28 @@ class NonClosingStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /**
-     * @var StreamInterface $stream
+     * @var ?StreamInterface $stream
+     * @phpstan-ignore-next-line
      */
     private $stream;
 
     /**
-     * Overridden to detach the underlying stream without closing it.
-     * @return void
+     * @inheritDoc
      */
-    public function close()
+    public function close() : void
     {
         $this->stream = null;
     }
 
     /**
      * Overridden to detach the underlying stream without closing it.
-     * @return resource|null Underlying PHP stream, if any
+     *
+     * @inheritDoc
      */
     public function detach()
     {
         $this->stream = null;
+
+        return null;
     }
 }

--- a/src/PregReplaceFilterStream.php
+++ b/src/PregReplaceFilterStream.php
@@ -4,11 +4,12 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\StreamDecorators;
 
-use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use GuzzleHttp\Psr7\BufferStream;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
 /**
@@ -43,7 +44,7 @@ class PregReplaceFilterStream implements StreamInterface
      */
     private $stream;
 
-    public function __construct(StreamInterface $stream, $pattern, $replacement)
+    public function __construct(StreamInterface $stream, string $pattern, string $replacement)
     {
         $this->stream = $stream;
         $this->pattern = $pattern;
@@ -53,10 +54,8 @@ class PregReplaceFilterStream implements StreamInterface
 
     /**
      * Returns true if the end of stream has been reached.
-     *
-     * @return boolean
      */
-    public function eof()
+    public function eof() : bool
     {
         return ($this->buffer->eof() && $this->stream->eof());
     }
@@ -75,10 +74,8 @@ class PregReplaceFilterStream implements StreamInterface
 
     /**
      * Overridden to return false
-     *
-     * @return boolean
      */
-    public function isSeekable()
+    public function isSeekable() : bool
     {
         return false;
     }
@@ -86,18 +83,16 @@ class PregReplaceFilterStream implements StreamInterface
     /**
      * Fills the BufferStream with at least 8192 characters of input for future
      * read operations.
-     *
-     * @param int $length
      */
-    private function fillBuffer($length)
+    private function fillBuffer(int $length) : void
     {
-        $fill = (int)max([$length, 8192]);
+        $fill = (int) \max([$length, 8192]);
         while ($this->buffer->getSize() < $length) {
             $read = $this->stream->read($fill);
-            if ($read === false || $read === '') {
+            if ($read === '') {
                 break;
             }
-            $this->buffer->write(preg_replace($this->pattern, $this->replacement, $read));
+            $this->buffer->write(\preg_replace($this->pattern, $this->replacement, $read));
         }
     }
 

--- a/src/QuotedPrintableStream.php
+++ b/src/QuotedPrintableStream.php
@@ -4,10 +4,11 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\StreamDecorators;
 
-use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
 /**
@@ -31,15 +32,14 @@ class QuotedPrintableStream implements StreamInterface
 
     /**
      * @var StreamInterface $stream
+     * @phpstan-ignore-next-line
      */
     private $stream;
 
     /**
      * Overridden to return the position in the target encoding.
-     *
-     * @return int
      */
-    public function tell()
+    public function tell() : int
     {
         return $this->position;
     }
@@ -49,7 +49,7 @@ class QuotedPrintableStream implements StreamInterface
      *
      * @return null
      */
-    public function getSize()
+    public function getSize() : ?int
     {
         return null;
     }
@@ -68,10 +68,8 @@ class QuotedPrintableStream implements StreamInterface
 
     /**
      * Overridden to return false
-     *
-     * @return boolean
      */
-    public function isSeekable()
+    public function isSeekable() : bool
     {
         return false;
     }
@@ -86,16 +84,12 @@ class QuotedPrintableStream implements StreamInterface
      *
      * The quoted-printable encoded characters are returned.  If the characters
      * read are invalid, '3D' is returned indicating an '=' character.
-     *
-     * @param int $length
-     * @param string $pre
-     * @return string
      */
-    private function readEncodedChars($length, $pre = '')
+    private function readEncodedChars(int $length, string $pre = '') : string
     {
         $str = $pre . $this->stream->read($length);
-        $len = strlen($str);
-        if ($len > 0 && !preg_match('/^[0-9a-f]{2}$|^[\r\n]{1,2}.?$/is', $str) && $this->stream->isSeekable()) {
+        $len = \strlen($str);
+        if ($len > 0 && !\preg_match('/^[0-9a-f]{2}$|^[\r\n]{1,2}.?$/is', $str) && $this->stream->isSeekable()) {
             $this->stream->seek(-$len, SEEK_CUR);
             return '3D';    // '=' character
         }
@@ -109,21 +103,18 @@ class QuotedPrintableStream implements StreamInterface
      * beginning of a quoted-printable encoded char, 1 or 2 additional bytes are
      * read from the underlying stream respectively.
      *
-     * The decoded string is returned.
-     *
-     * @param string $block
-     * @return string
+     * @return string The decoded string
      */
-    private function decodeBlock($block)
+    private function decodeBlock(string $block) : string
     {
-        if (substr($block, -1) === '=') {
+        if (\substr($block, -1) === '=') {
             $block .= $this->readEncodedChars(2);
-        } elseif (substr($block, -2, 1) === '=') {
-            $first = substr($block, -1);
-            $block = substr($block, 0, -1);
+        } elseif (\substr($block, -2, 1) === '=') {
+            $first = \substr($block, -1);
+            $block = \substr($block, 0, -1);
             $block .= $this->readEncodedChars(1, $first);
         }
-        return quoted_printable_decode($block);
+        return \quoted_printable_decode($block);
     }
 
     /**
@@ -131,19 +122,15 @@ class QuotedPrintableStream implements StreamInterface
      * and returns the total number of characters read.
      *
      * -1 is returned if there are no more bytes to read.
-     *
-     * @param int $length
-     * @param string $append
-     * @return int
      */
-    private function readRawDecodeAndAppend($length, &$str)
+    private function readRawDecodeAndAppend(int $length, string &$str) : int
     {
         $block = $this->stream->read($length);
-        if ($block === false || $block === '') {
+        if ($block === '') {
             return -1;
         }
         $decoded = $this->decodeBlock($block);
-        $count = strlen($decoded);
+        $count = \strlen($decoded);
         $str .= $decoded;
         return $count;
     }
@@ -153,9 +140,8 @@ class QuotedPrintableStream implements StreamInterface
      * encoded stream and returns them.
      *
      * @param int $length
-     * @return string
      */
-    public function read($length)
+    public function read($length) : string
     {
         // let Guzzle decide what to do.
         if ($length <= 0 || $this->eof()) {
@@ -182,30 +168,31 @@ class QuotedPrintableStream implements StreamInterface
      * supported.
      *
      * @param string $string
+     *
      * @return int the number of bytes written
      */
-    public function write($string)
+    public function write($string) : int
     {
-        $encodedLine = quoted_printable_encode($this->lastLine);
-        $lineAndString = rtrim(quoted_printable_encode($this->lastLine . $string), "\r\n");
-        $write = substr($lineAndString, strlen($encodedLine));
+        $encodedLine = \quoted_printable_encode($this->lastLine);
+        $lineAndString = \rtrim(\quoted_printable_encode($this->lastLine . $string), "\r\n");
+        $write = \substr($lineAndString, \strlen($encodedLine));
         $this->stream->write($write);
-        $written = strlen($string);
+        $written = \strlen($string);
         $this->position += $written;
 
-        $lpos = strrpos($lineAndString, "\n");
+        $lpos = \strrpos($lineAndString, "\n");
         $lastLine = $lineAndString;
         if ($lpos !== false) {
-            $lastLine = substr($lineAndString, $lpos + 1);
+            $lastLine = \substr($lineAndString, $lpos + 1);
         }
-        $this->lastLine = quoted_printable_decode($lastLine);
+        $this->lastLine = \quoted_printable_decode($lastLine);
         return $written;
     }
 
     /**
      * Writes out a final CRLF if the current line isn't empty.
      */
-    private function beforeClose()
+    private function beforeClose() : void
     {
         if ($this->isWritable() && $this->lastLine !== '') {
             $this->stream->write("\r\n");
@@ -214,24 +201,22 @@ class QuotedPrintableStream implements StreamInterface
     }
 
     /**
-     * Closes the underlying stream and writes a final CRLF if the current line
-     * isn't empty.
-     * @return void
+     * @inheritDoc
      */
-    public function close()
+    public function close() : void
     {
         $this->beforeClose();
         $this->stream->close();
     }
 
     /**
-     * Closes the underlying stream and writes a final CRLF if the current line
-     * isn't empty.
-     * @return resource|null Underlying PHP stream, if any
+     * @inheritDoc
      */
     public function detach()
     {
         $this->beforeClose();
         $this->stream->detach();
+
+        return null;
     }
 }

--- a/src/SeekingLimitStream.php
+++ b/src/SeekingLimitStream.php
@@ -4,10 +4,11 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\StreamDecorators;
 
-use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Maintains an internal 'read' position, and seeks to it before reading, then
@@ -50,11 +51,8 @@ class SeekingLimitStream implements StreamInterface
      * @param int             $offset Position to seek to before reading (only
      *                                works on seekable streams).
      */
-    public function __construct(
-        StreamInterface $stream,
-        $limit = -1,
-        $offset = 0
-    ) {
+    public function __construct(StreamInterface $stream, int $limit = -1, int $offset = 0)
+    {
         $this->stream = $stream;
         $this->setLimit($limit);
         $this->setOffset($offset);
@@ -62,10 +60,8 @@ class SeekingLimitStream implements StreamInterface
 
     /**
      * Returns the current relative read position of this stream subset.
-     *
-     * @return int
      */
-    public function tell()
+    public function tell() : int
     {
         return $this->position;
     }
@@ -73,10 +69,8 @@ class SeekingLimitStream implements StreamInterface
     /**
      * Returns the size of the limited subset of data, or null if the wrapped
      * stream returns null for getSize.
-     *
-     * @return int|null
      */
-    public function getSize()
+    public function getSize() : ?int
     {
         $size = $this->stream->getSize();
         if ($size === null) {
@@ -90,16 +84,14 @@ class SeekingLimitStream implements StreamInterface
             return $size - $this->offset;
         }
 
-        return min([$this->limit, $size - $this->offset]);
+        return \min([$this->limit, $size - $this->offset]);
     }
 
     /**
      * Returns true if the current read position is at the end of the limited
      * stream
-     *
-     * @return boolean
      */
-    public function eof()
+    public function eof() : bool
     {
         $size = $this->limit;
         if ($size === -1) {
@@ -111,15 +103,13 @@ class SeekingLimitStream implements StreamInterface
     /**
      * Ensures the seek position specified is within the stream's bounds, and
      * sets the internal position pointer (doesn't actually seek).
-     *
-     * @param int $pos
      */
-    private function doSeek($pos)
+    private function doSeek(int $pos) : void
     {
         if ($this->limit !== -1) {
-            $pos = min([$pos, $this->limit]);
+            $pos = \min([$pos, $this->limit]);
         }
-        $this->position = max([0, $pos]);
+        $this->position = \max([0, $pos]);
     }
 
     /**
@@ -151,11 +141,8 @@ class SeekingLimitStream implements StreamInterface
 
     /**
      * Sets the offset to start reading from the wrapped stream.
-     *
-     * @param int $offset
-     * @throws \RuntimeException if the stream cannot be seeked.
      */
-    public function setOffset($offset)
+    public function setOffset(int $offset) : void
     {
         $this->offset = $offset;
         $this->position = 0;
@@ -163,10 +150,8 @@ class SeekingLimitStream implements StreamInterface
 
     /**
      * Sets the length of the stream to the passed $limit.
-     *
-     * @param int $limit
      */
-    public function setLimit($limit)
+    public function setLimit(int $limit) : void
     {
         $this->limit = $limit;
     }
@@ -174,15 +159,12 @@ class SeekingLimitStream implements StreamInterface
     /**
      * Seeks to the current position and reads up to $length bytes, or less if
      * it would result in reading past $this->limit
-     *
-     * @param int $length
-     * @return string
      */
-    public function seekAndRead($length)
+    public function seekAndRead(int $length) : string
     {
         $this->stream->seek($this->offset + $this->position);
         if ($this->limit !== -1) {
-            $length = min($length, $this->limit - $this->position);
+            $length = \min($length, $this->limit - $this->position);
             if ($length <= 0) {
                 return '';
             }
@@ -202,10 +184,10 @@ class SeekingLimitStream implements StreamInterface
     {
         $pos = $this->stream->tell();
         $ret = $this->seekAndRead($length);
-        $this->position += strlen($ret);
+        $this->position += \strlen($ret);
         $this->stream->seek($pos);
         if ($this->limit !== -1 && $this->position > $this->limit) {
-            $ret = substr($ret, 0, -($this->position - $this->limit));
+            $ret = \substr($ret, 0, -($this->position - $this->limit));
             $this->position = $this->limit;
         }
         return $ret;

--- a/src/UUStream.php
+++ b/src/UUStream.php
@@ -4,11 +4,12 @@
  *
  * @license http://opensource.org/licenses/bsd-license.php BSD
  */
+
 namespace ZBateson\StreamDecorators;
 
-use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use GuzzleHttp\Psr7\BufferStream;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
 /**
@@ -46,7 +47,7 @@ class UUStream implements StreamInterface
     private $position = 0;
 
     /**
-     * @var boolean set to true when 'write' is called
+     * @var bool set to true when 'write' is called
      */
     private $isWriting = false;
 
@@ -59,7 +60,7 @@ class UUStream implements StreamInterface
      * @param StreamInterface $stream Stream to decorate
      * @param string $filename optional file name
      */
-    public function __construct(StreamInterface $stream, $filename = null)
+    public function __construct(StreamInterface $stream, ?string $filename = null)
     {
         $this->stream = $stream;
         $this->filename = $filename;
@@ -68,10 +69,8 @@ class UUStream implements StreamInterface
 
     /**
      * Overridden to return the position in the target encoding.
-     *
-     * @return int
      */
-    public function tell()
+    public function tell() : int
     {
         return $this->position;
     }
@@ -81,7 +80,7 @@ class UUStream implements StreamInterface
      *
      * @return null
      */
-    public function getSize()
+    public function getSize() : ?int
     {
         return null;
     }
@@ -100,10 +99,8 @@ class UUStream implements StreamInterface
 
     /**
      * Overridden to return false
-     *
-     * @return boolean
      */
-    public function isSeekable()
+    public function isSeekable() : bool
     {
         return false;
     }
@@ -111,18 +108,16 @@ class UUStream implements StreamInterface
     /**
      * Finds the next end-of-line character to ensure a line isn't broken up
      * while buffering.
-     *
-     * @return string
      */
-    private function readToEndOfLine($length)
+    private function readToEndOfLine(int $length) : string
     {
         $str = $this->stream->read($length);
-        if ($str === false || $str === '') {
+        if ($str === '') {
             return $str;
         }
-        while (substr($str, -1) !== "\n") {
+        while (\substr($str, -1) !== "\n") {
             $chr = $this->stream->read(1);
-            if ($chr === false || $chr === '') {
+            if ($chr === '') {
                 break;
             }
             $str .= $chr;
@@ -133,38 +128,35 @@ class UUStream implements StreamInterface
     /**
      * Removes invalid characters from a uuencoded string, and 'BEGIN' and 'END'
      * line headers and footers from the passed string before returning it.
-     *
-     * @param string $str
-     * @return string
      */
-    private function filterAndDecode($str)
+    private function filterAndDecode(string $str) : string
     {
-        $ret = str_replace("\r", '', $str);
-        $ret = preg_replace('/[^\x21-\xf5`\n]/', '`', $ret);
+        $ret = \str_replace("\r", '', $str);
+        $ret = \preg_replace('/[^\x21-\xf5`\n]/', '`', $ret);
         if ($this->position === 0) {
             $matches = [];
-            if (preg_match('/^\s*begin\s+[^\s+]\s+([^\r\n]+)\s*$/im', $ret, $matches)) {
+            if (\preg_match('/^\s*begin\s+[^\s+]\s+([^\r\n]+)\s*$/im', $ret, $matches)) {
                 $this->filename = $matches[1];
             }
-            $ret = preg_replace('/^\s*begin[^\r\n]+\s*$/im', '', $ret);
+            $ret = \preg_replace('/^\s*begin[^\r\n]+\s*$/im', '', $ret);
         } else {
-            $ret = preg_replace('/^\s*end\s*$/im', '', $ret);
+            $ret = \preg_replace('/^\s*end\s*$/im', '', $ret);
         }
-        return convert_uudecode(trim($ret));
+        return \convert_uudecode(\trim($ret));
     }
 
     /**
      * Buffers bytes into $this->buffer, removing uuencoding headers and footers
      * and decoding them.
      */
-    private function fillBuffer($length)
+    private function fillBuffer(int $length) : void
     {
         // 5040 = 63 * 80, seems to be good balance for buffering in benchmarks
         // testing with a simple 'if ($length < x)' and calculating a better
         // size reduces speeds by up to 4x
         while ($this->buffer->getSize() < $length) {
             $read = $this->readToEndOfLine(5040);
-            if ($read === false || $read === '') {
+            if ($read === '') {
                 break;
             }
             $this->buffer->write($this->filterAndDecode($read));
@@ -173,10 +165,8 @@ class UUStream implements StreamInterface
 
     /**
      * Returns true if the end of stream has been reached.
-     *
-     * @return boolean
      */
-    public function eof()
+    public function eof() : bool
     {
         return ($this->buffer->eof() && $this->stream->eof());
     }
@@ -185,9 +175,8 @@ class UUStream implements StreamInterface
      * Attempts to read $length bytes after decoding them, and returns them.
      *
      * @param int $length
-     * @return string
      */
-    public function read($length)
+    public function read($length) : string
     {
         // let Guzzle decide what to do.
         if ($length <= 0 || $this->eof()) {
@@ -195,14 +184,14 @@ class UUStream implements StreamInterface
         }
         $this->fillBuffer($length);
         $read = $this->buffer->read($length);
-        $this->position += strlen($read);
+        $this->position += \strlen($read);
         return $read;
     }
 
     /**
      * Writes the 'begin' UU header line.
      */
-    private function writeUUHeader()
+    private function writeUUHeader() : void
     {
         $filename = (empty($this->filename)) ? 'null' : $this->filename;
         $this->stream->write("begin 666 $filename");
@@ -211,39 +200,34 @@ class UUStream implements StreamInterface
     /**
      * Writes the '`' and 'end' UU footer lines.
      */
-    private function writeUUFooter()
+    private function writeUUFooter() : void
     {
         $this->stream->write("\r\n`\r\nend\r\n");
     }
 
     /**
      * Writes the passed bytes to the underlying stream after encoding them.
-     *
-     * @param string $bytes
      */
-    private function writeEncoded($bytes)
+    private function writeEncoded(string $bytes) : void
     {
-        $encoded = preg_replace('/\r\n|\r|\n/', "\r\n", rtrim(convert_uuencode($bytes)));
+        $encoded = \preg_replace('/\r\n|\r|\n/', "\r\n", \rtrim(\convert_uuencode($bytes)));
         // removes ending '`' line
-        $this->stream->write("\r\n" . rtrim(substr($encoded, 0, -1)));
+        $this->stream->write("\r\n" . \rtrim(\substr($encoded, 0, -1)));
     }
 
     /**
      * Prepends any existing remainder to the passed string, then checks if the
      * string fits into a uuencoded line, and removes and keeps any remainder
      * from the string to write.  Full lines ready for writing are returned.
-     *
-     * @param string $string
-     * @return string
      */
-    private function handleRemainder($string)
+    private function handleRemainder(string $string) : string
     {
         $write = $this->remainder . $string;
-        $nRem = strlen($write) % 45;
+        $nRem = \strlen($write) % 45;
         $this->remainder = '';
         if ($nRem !== 0) {
-            $this->remainder = substr($write, -$nRem);
-            $write = substr($write, 0, -$nRem);
+            $this->remainder = \substr($write, -$nRem);
+            $write = \substr($write, 0, -$nRem);
         }
         return $write;
     }
@@ -262,7 +246,7 @@ class UUStream implements StreamInterface
      * @param string $string
      * @return int the number of bytes written
      */
-    public function write($string)
+    public function write($string) : int
     {
         $this->isWriting = true;
         if ($this->position === 0) {
@@ -272,27 +256,23 @@ class UUStream implements StreamInterface
         if ($write !== '') {
             $this->writeEncoded($write);
         }
-        $written = strlen($string);
+        $written = \strlen($string);
         $this->position += $written;
         return $written;
     }
 
     /**
      * Returns the filename set in the UUEncoded header (or null)
-     *
-     * @return string
      */
-    public function getFilename()
+    public function getFilename() : string
     {
         return $this->filename;
     }
 
     /**
      * Sets the UUEncoded header file name written in the 'begin' header line.
-     *
-     * @param string $filename
      */
-    public function setFilename($filename)
+    public function setFilename(string $filename) : void
     {
         $this->filename = $filename;
     }
@@ -300,7 +280,7 @@ class UUStream implements StreamInterface
     /**
      * Writes out any remaining bytes and the UU footer.
      */
-    private function beforeClose()
+    private function beforeClose() : void
     {
         if (!$this->isWriting) {
             return;
@@ -314,24 +294,22 @@ class UUStream implements StreamInterface
     }
 
     /**
-     * Writes any remaining bytes out followed by the uu-encoded footer, then
-     * closes the stream.
-     * @return void
+     * @inheritDoc
      */
-    public function close()
+    public function close() : void
     {
         $this->beforeClose();
         $this->stream->close();
     }
 
     /**
-     * Writes any remaining bytes out followed by the uu-encoded footer, then
-     * detaches the stream.
-     * @return resource|null Underlying PHP stream, if any
+     * @inheritDoc
      */
     public function detach()
     {
         $this->beforeClose();
         $this->stream->detach();
+
+        return null;
     }
 }

--- a/tests/StreamDecorators/Base64StreamTest.php
+++ b/tests/StreamDecorators/Base64StreamTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\StreamWrapper;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
@@ -15,7 +16,7 @@ use RuntimeException;
  */
 class Base64StreamTest extends TestCase
 {
-    public function testReadContents()
+    public function testReadContents() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -23,15 +24,15 @@ class Base64StreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        for ($i = 0; $i < strlen($str); ++$i) {
-            $substr = substr($str, 0, $i + 1);
-            $stream = Psr7\Utils::streamFor(base64_encode($substr));
+        for ($i = 0; $i < \strlen($str); ++$i) {
+            $substr = \substr($str, 0, $i + 1);
+            $stream = Psr7\Utils::streamFor(\base64_encode($substr));
             $b64Stream = new Base64Stream($stream);
             $this->assertSame($substr, $b64Stream->getContents());
         }
     }
 
-    public function testReadToEof()
+    public function testReadToEof() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -39,24 +40,24 @@ class Base64StreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        for ($i = 0; $i < strlen($str); ++$i) {
-            $stream = Psr7\Utils::streamFor(base64_encode(substr($str, $i)));
+        for ($i = 0; $i < \strlen($str); ++$i) {
+            $stream = Psr7\Utils::streamFor(\base64_encode(\substr($str, $i)));
             $b64Stream = new Base64Stream($stream);
             for ($j = $i; !$b64Stream->eof(); ++$j) {
-                $this->assertEquals(substr($str, $j, 1), $b64Stream->read(1), "Failed reading to EOF on substr $i iteration $j");
+                $this->assertEquals(\substr($str, $j, 1), $b64Stream->read(1), "Failed reading to EOF on substr $i iteration $j");
             }
         }
     }
 
-    public function testGetSize()
+    public function testGetSize() : void
     {
         $str = 'Sweetest little pie';
-        $stream = Psr7\Utils::streamFor(base64_encode($str));
+        $stream = Psr7\Utils::streamFor(\base64_encode($str));
         $b64Stream = new Base64Stream($stream);
         $this->assertNull($b64Stream->getSize());
     }
 
-    public function testTell()
+    public function testTell() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -64,63 +65,63 @@ class Base64StreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        $stream = Psr7\Utils::streamFor(base64_encode($str));
-        for ($i = 1; $i < strlen($str); ++$i) {
+        $stream = Psr7\Utils::streamFor(\base64_encode($str));
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $b64Stream = new Base64Stream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
+            for ($j = 0; $j < \strlen($str); $j += $i) {
                 $this->assertSame($j, $b64Stream->tell(), "Tell at $j failed with $i step");
                 $b64Stream->read($i);
             }
-            $this->assertSame(strlen($str), $b64Stream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $b64Stream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testDecodeFile()
+    public function testDecodeFile() : void
     {
         $encoded = __DIR__ . '/../_data/blueball.b64.txt';
         $org = __DIR__ . '/../_data/blueball.png';
-        $f = fopen($encoded, 'r');
+        $f = \fopen($encoded, 'r');
 
         $streamDecorator = new Base64Stream(new PregReplaceFilterStream(Psr7\Utils::streamFor($f), '/[^a-zA-Z0-9\/\+=]/', ''));
         $handle = StreamWrapper::getResource($streamDecorator);
 
-        $this->assertSame(file_get_contents($org), stream_get_contents($handle), 'Decoded blueball not equal to original file');
+        $this->assertSame(\file_get_contents($org), \stream_get_contents($handle), 'Decoded blueball not equal to original file');
 
-        fclose($handle);
-        fclose($f);
+        \fclose($handle);
+        \fclose($f);
     }
 
-    public function testDecodeWordFileWithStreamGetContents()
+    public function testDecodeWordFileWithStreamGetContents() : void
     {
         $encoded = __DIR__ . '/../_data/test.b64.txt';
         $org = __DIR__ . '/../_data/test.doc';
-        $f = fopen($encoded, 'r');
+        $f = \fopen($encoded, 'r');
 
         $streamDecorator = new Base64Stream(new PregReplaceFilterStream(Psr7\Utils::streamFor($f), '/[^a-zA-Z0-9\/\+=]/', ''));
         $handle = StreamWrapper::getResource($streamDecorator);
 
-        $horg = fopen($org, 'r');
-        $this->assertSame(stream_get_contents($horg), stream_get_contents($handle));
+        $horg = \fopen($org, 'r');
+        $this->assertSame(\stream_get_contents($horg), \stream_get_contents($handle));
 
-        fclose($horg);
-        fclose($handle);
-        fclose($f);
+        \fclose($horg);
+        \fclose($handle);
+        \fclose($f);
     }
 
-    public function testWriteAndDetach()
+    public function testWriteAndDetach() : void
     {
         $org = __DIR__ . '/../_data/blueball.png';
-        $contents = file_get_contents($org);
+        $contents = \file_get_contents($org);
 
-        for ($i = 1; $i < strlen($contents); ++$i) {
+        for ($i = 1; $i < \strlen($contents); ++$i) {
 
-            $f = fopen('php://temp', 'r+');
+            $f = \fopen('php://temp', 'r+');
             $stream = Psr7\Utils::streamFor($f);
 
             $ostream = new Base64Stream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($contents); $j += $i) {
-                $ostream->write(substr($contents, $j, $i));
+            for ($j = 0; $j < \strlen($contents); $j += $i) {
+                $ostream->write(\substr($contents, $j, $i));
             }
             $ostream->detach();
 
@@ -130,7 +131,7 @@ class Base64StreamTest extends TestCase
         }
     }
 
-    public function testWriteDifferentContentLengths()
+    public function testWriteDifferentContentLengths() : void
     {
         $contents = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -139,15 +140,15 @@ class Base64StreamTest extends TestCase
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
 
-        for ($i = 1; $i < strlen($contents); ++$i) {
+        for ($i = 1; $i < \strlen($contents); ++$i) {
 
-            $str = substr($contents, 0, strlen($contents) - $i);
-            $f = fopen('php://temp', 'r+');
+            $str = \substr($contents, 0, \strlen($contents) - $i);
+            $f = \fopen('php://temp', 'r+');
             $stream = Psr7\Utils::streamFor($f);
 
             $ostream = new Base64Stream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
-                $ostream->write(substr($str, $j, $i));
+            for ($j = 0; $j < \strlen($str); $j += $i) {
+                $ostream->write(\substr($str, $j, $i));
             }
             $ostream->close();
 
@@ -157,10 +158,10 @@ class Base64StreamTest extends TestCase
         }
     }
 
-    public function testSeekUnsopported()
+    public function testSeekUnsopported() : void
     {
         $str = 'Sweetest little pie';
-        $stream = Psr7\Utils::streamFor(base64_encode($str));
+        $stream = Psr7\Utils::streamFor(\base64_encode($str));
         $test = new Base64Stream($stream);
         $this->assertFalse($test->isSeekable());
         $exceptionThrown = false;

--- a/tests/StreamDecorators/CharsetStreamTest.php
+++ b/tests/StreamDecorators/CharsetStreamTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\StreamWrapper;
-use ZBateson\MbWrapper\MbWrapper;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use ZBateson\MbWrapper\MbWrapper;
 
 /**
  * Description of CharsetStreamTest
@@ -16,81 +16,84 @@ use RuntimeException;
  */
 class CharsetStreamTest extends TestCase
 {
+    /**
+     * @var MbWrapper
+     */
     private $converter;
 
-    protected function legacySetUp()
+    protected function SetUp() : void
     {
         $this->converter = new MbWrapper();
     }
 
-    public function testRead()
+    public function testRead() : void
     {
-        $str = str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 50);
+        $str = \str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 50);
 
         $stream = Psr7\Utils::streamFor($this->converter->convert($str, 'UTF-8', 'UTF-32'));
-        for ($i = 1; $i < mb_strlen($str, 'UTF-8'); ++$i) {
+        for ($i = 1; $i < \mb_strlen($str, 'UTF-8'); ++$i) {
             $stream->rewind();
             $csStream = new CharsetStream(new NonClosingStream($stream), 'UTF-32', 'UTF-8');
-            for ($j = 0; $j < mb_strlen($str, 'UTF-8'); $j += $i) {
+            for ($j = 0; $j < \mb_strlen($str, 'UTF-8'); $j += $i) {
                 $char = $csStream->read($i);
-                $this->assertSame(mb_substr($str, $j, $i, 'UTF-8'), $char, "Read $j failed at $i step");
+                $this->assertSame(\mb_substr($str, $j, $i, 'UTF-8'), $char, "Read $j failed at $i step");
             }
-            $this->assertSame(mb_strlen($str, 'UTF-8'), $csStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\mb_strlen($str, 'UTF-8'), $csStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testReadContents()
+    public function testReadContents() : void
     {
-        $str = str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 50);
+        $str = \str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 50);
 
-        for ($i = 0; $i < mb_strlen($str); ++$i) {
-            $substr = mb_substr($str, 0, $i + 1, 'UTF-8');
+        for ($i = 0; $i < \mb_strlen($str); ++$i) {
+            $substr = \mb_substr($str, 0, $i + 1, 'UTF-8');
             $stream = Psr7\Utils::streamFor($this->converter->convert($substr, 'UTF-8', 'UTF-16'));
             $csStream = new CharsetStream($stream, 'UTF-16', 'UTF-8');
             $this->assertSame($substr, $csStream->getContents());
         }
     }
 
-    public function testReadToEof()
+    public function testReadToEof() : void
     {
-        $str = str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
-        for ($i = 0; $i < mb_strlen($str, 'UTF-8'); ++$i) {
-            $substr = mb_substr($str, $i, null, 'UTF-8');
+        $str = \str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
+        for ($i = 0; $i < \mb_strlen($str, 'UTF-8'); ++$i) {
+            $substr = \mb_substr($str, $i, null, 'UTF-8');
             $stream = Psr7\Utils::streamFor($this->converter->convert($substr, 'UTF-8', 'WINDOWS-1256'));
             $csStream = new CharsetStream($stream, 'WINDOWS-1256', 'UTF-8');
             for ($j = 0; !$csStream->eof(); ++$j) {
                 $read = $csStream->read(1);
-                $this->assertSame(mb_substr($substr, $j, 1, 'UTF-8'), $read, "Failed reading to EOF on substr $i iteration $j");
+                $this->assertSame(\mb_substr($substr, $j, 1, 'UTF-8'), $read, "Failed reading to EOF on substr $i iteration $j");
             }
         }
     }
 
-    public function testReadUtf16LeToEof()
+    public function testReadUtf16LeToEof() : void
     {
-        $str = str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
-        for ($i = 0; $i < mb_strlen($str, 'UTF-8'); ++$i) {
-            $substr = mb_substr($str, $i, null, 'UTF-8');
+        $str = \str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
+        for ($i = 0; $i < \mb_strlen($str, 'UTF-8'); ++$i) {
+            $substr = \mb_substr($str, $i, null, 'UTF-8');
             $stream = Psr7\Utils::streamFor($this->converter->convert($substr, 'UTF-8', 'UTF-16LE'));
             $csStream = new CharsetStream($stream, 'UTF-16LE', 'UTF-8');
             for ($j = 0; !$csStream->eof(); ++$j) {
                 $read = $csStream->read(1);
-                $this->assertSame(mb_substr($substr, $j, 1, 'UTF-8'), $read, "Failed reading to EOF on substr $i iteration $j");
+                $this->assertSame(\mb_substr($substr, $j, 1, 'UTF-8'), $read, "Failed reading to EOF on substr $i iteration $j");
             }
         }
     }
 
-    public function testReadToEmpty()
+    public function testReadToEmpty() : void
     {
-        $str = str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
+        $str = \str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
         $stream = Psr7\Utils::streamFor($this->converter->convert($str, 'UTF-8', 'WINDOWS-1256'));
         $csStream = new CharsetStream($stream, 'WINDOWS-1256', 'UTF-8');
         $i = 0;
         while (($chr = $csStream->read(1)) !== '') {
-            $this->assertSame(mb_substr($str, $i++, 1, 'UTF-8'), $chr, "Failed reading to false on substr $i");
+            $this->assertSame(\mb_substr($str, $i++, 1, 'UTF-8'), $chr, "Failed reading to false on substr $i");
         }
     }
 
-    public function testGetSize()
+    public function testGetSize() : void
     {
         $str = 'Sweetest little pie';
         $stream = Psr7\Utils::streamFor($this->converter->convert($str, 'UTF-8', 'UTF-16'));
@@ -98,7 +101,7 @@ class CharsetStreamTest extends TestCase
         $this->assertNull($csStream->getSize());
     }
 
-    public function testTell()
+    public function testTell() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -108,18 +111,18 @@ class CharsetStreamTest extends TestCase
             . 'vulgaire.é';
         $stream = Psr7\Utils::streamFor($str);
 
-        for ($i = 1; $i < strlen($str); ++$i) {
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $csStream = new CharsetStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
+            for ($j = 0; $j < \strlen($str); $j += $i) {
                 $this->assertSame($j, $csStream->tell(), "Tell at $j failed with $i step");
                 $csStream->read($i);
             }
-            $this->assertSame(strlen($str), $csStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $csStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testSeekUnsopported()
+    public function testSeekUnsopported() : void
     {
         $stream = Psr7\Utils::streamFor('Sweetest little pie');
         $test = new CharsetStream($stream);
@@ -133,14 +136,14 @@ class CharsetStreamTest extends TestCase
         $this->assertTrue($exceptionThrown);
     }
 
-    public function testWrite()
+    public function testWrite() : void
     {
-        $str = str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
-        for ($i = 1; $i < mb_strlen($str); ++$i) {
-            $stream = Psr7\Utils::streamFor(fopen('php://temp', 'r+'));
+        $str = \str_repeat('هلا هلا شخبار بعد؟ شلون تبرمج؟', 10);
+        for ($i = 1; $i < \mb_strlen($str); ++$i) {
+            $stream = Psr7\Utils::streamFor(\fopen('php://temp', 'r+'));
             $oStream = new CharsetStream(new NonClosingStream($stream), 'UTF-32', 'UTF-8');
-            for ($j = 0; $j < mb_strlen($str, 'UTF-8'); $j += $i) {
-                $oStream->write(mb_substr($str, $j, $i, 'UTF-8'));
+            for ($j = 0; $j < \mb_strlen($str, 'UTF-8'); $j += $i) {
+                $oStream->write(\mb_substr($str, $j, $i, 'UTF-8'));
             }
             $stream->rewind();
 
@@ -150,7 +153,7 @@ class CharsetStreamTest extends TestCase
             $stream->rewind();
             $streamContents = $stream->getContents();
             $this->assertNotEquals($str, $streamContents);
-            $this->assertGreaterThan(strlen($str), strlen($streamContents));
+            $this->assertGreaterThan(\strlen($str), \strlen($streamContents));
             $this->assertSame($str, $this->converter->convert($streamContents, 'UTF-32', 'UTF-8'));
         }
     }

--- a/tests/StreamDecorators/ChunkSplitStreamTest.php
+++ b/tests/StreamDecorators/ChunkSplitStreamTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of ChunkSplitStreamTest
@@ -13,14 +14,14 @@ use GuzzleHttp\Psr7;
  */
 class ChunkSplitStreamTest extends TestCase
 {
-    public function testWrite()
+    public function testWrite() : void
     {
         $stream = Psr7\Utils::streamFor('');
 
         $out = new ChunkSplitStream(new NonClosingStream($stream), 10, '|');
-        $out->write(str_repeat('a', 5));
-        $out->write(str_repeat('a', 10));
-        $out->write(str_repeat('a', 4));
+        $out->write(\str_repeat('a', 5));
+        $out->write(\str_repeat('a', 10));
+        $out->write(\str_repeat('a', 4));
         for ($i = 0; $i < 16; ++$i) {
             $out->write('a');
         }
@@ -28,18 +29,18 @@ class ChunkSplitStreamTest extends TestCase
 
         $stream->rewind();
         $str = $stream->getContents();
-        $arr = explode('|', $str);
+        $arr = \explode('|', $str);
 
         $this->assertStringEndsWith('|', $str);
         $this->assertCount(5, $arr);
-        $this->assertSame(10, strlen($arr[0]));
-        $this->assertSame(10, strlen($arr[1]));
-        $this->assertSame(10, strlen($arr[2]));
-        $this->assertSame(5, strlen($arr[3]));
+        $this->assertSame(10, \strlen($arr[0]));
+        $this->assertSame(10, \strlen($arr[1]));
+        $this->assertSame(10, \strlen($arr[2]));
+        $this->assertSame(5, \strlen($arr[3]));
         $this->assertEmpty($arr[4]);
     }
 
-    public function testWriteLineEndingAtBoundary()
+    public function testWriteLineEndingAtBoundary() : void
     {
         $stream = Psr7\Utils::streamFor('');
 
@@ -51,12 +52,12 @@ class ChunkSplitStreamTest extends TestCase
 
         $stream->rewind();
         $str = $stream->getContents();
-        $arr = explode('|', $str);
+        $arr = \explode('|', $str);
 
         $this->assertStringEndsWith('|', $str);
         $this->assertCount(3, $arr);
-        $this->assertSame(10, strlen($arr[0]));
-        $this->assertSame(10, strlen($arr[1]));
+        $this->assertSame(10, \strlen($arr[0]));
+        $this->assertSame(10, \strlen($arr[1]));
         $this->assertEmpty($arr[2]);
     }
 }

--- a/tests/StreamDecorators/NonClosingStreamTest.php
+++ b/tests/StreamDecorators/NonClosingStreamTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of NonClosingStreamTest
@@ -13,7 +14,7 @@ use GuzzleHttp\Psr7;
  */
 class NonClosingStreamTest extends TestCase
 {
-    public function testClose()
+    public function testClose() : void
     {
         $str = 'Testacular';
         $org = Psr7\Utils::streamFor($str);
@@ -22,7 +23,7 @@ class NonClosingStreamTest extends TestCase
         $this->assertSame($org->getContents(), 'Testacular');
     }
 
-    public function testDetach()
+    public function testDetach() : void
     {
         $str = 'Testacular';
         $org = Psr7\Utils::streamFor($str);

--- a/tests/StreamDecorators/OnlyAsciiFileNamesTest.php
+++ b/tests/StreamDecorators/OnlyAsciiFileNamesTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -16,13 +17,13 @@ use RecursiveIteratorIterator;
  */
 class OnlyAsciiFileNamesTest extends TestCase
 {
-    public function testFileNames()
+    public function testFileNames() : void
     {
-        $dir = new RecursiveDirectoryIterator(dirname(__DIR__), FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::SKIP_DOTS);
+        $dir = new RecursiveDirectoryIterator(\dirname(__DIR__), FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::SKIP_DOTS);
         $iter = new RecursiveIteratorIterator($dir);
         foreach ($iter as $f) {
             $this->assertTrue(
-                mb_check_encoding($f->getFileName(), 'ASCII'),
+                \mb_check_encoding($f->getFileName(), 'ASCII'),
                 $f->getFileName() . ' contains non-ascii characters, which may '
                     . 'cause problems with some \'unzip\' utilities when '
                     . 'installing via composer'

--- a/tests/StreamDecorators/PregReplaceFilterStreamTest.php
+++ b/tests/StreamDecorators/PregReplaceFilterStreamTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
@@ -14,26 +15,26 @@ use RuntimeException;
  */
 class PregReplaceFilterStreamTest extends TestCase
 {
-    public function testRead()
+    public function testRead() : void
     {
         $stream = Psr7\Utils::streamFor('a-ll t-h-e k-ing\'s me-n');
         $test = new PregReplaceFilterStream($stream, '/\-/', '');
         $this->assertSame('all the king\'s men', $test->getContents());
     }
 
-    public function testReadBuffered()
+    public function testReadBuffered() : void
     {
-        $str = str_repeat('All the King\'s Men ', 8000);
-        $filter = str_repeat('A-l-l t-h-e K-in-g\'s M-en ', 8000);
+        $str = \str_repeat('All the King\'s Men ', 8000);
+        $filter = \str_repeat('A-l-l t-h-e K-in-g\'s M-en ', 8000);
         $stream = Psr7\Utils::streamFor($filter);
 
         $test = new PregReplaceFilterStream($stream, '/\-/', '');
-        for ($i = 0; $i < strlen($str); $i += 10) {
-            $this->assertSame(substr($str, $i, 10), $test->read(10));
+        for ($i = 0; $i < \strlen($str); $i += 10) {
+            $this->assertSame(\substr($str, $i, 10), $test->read(10));
         }
     }
 
-    public function testSeekUnsopported()
+    public function testSeekUnsopported() : void
     {
         $stream = Psr7\Utils::streamFor('a-ll t-h-e k-ing\'s me-n');
         $test = new PregReplaceFilterStream($stream, '/\-/', '');

--- a/tests/StreamDecorators/QuotedPrintableStreamTest.php
+++ b/tests/StreamDecorators/QuotedPrintableStreamTest.php
@@ -1,11 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\StreamWrapper;
-use GuzzleHttp\Psr7\LimitStream;
-use GuzzleHttp\Psr7\CachingStream;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
@@ -17,28 +15,28 @@ use RuntimeException;
  */
 class QuotedPrintableStreamTest extends TestCase
 {
-    public function testReadAndRewind()
+    public function testReadAndRewind() : void
     {
         // borrowed from wikipedia's quoted printable article, added non-ascii
         // start character and end character
-        $str = str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
+        $str = \str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
             . 'n\'est par essence qu\'un moyen, et te trompant ainsi sur la '
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é', 10);
-        $stream = Psr7\Utils::streamFor(quoted_printable_encode($str));
-        for ($i = 1; $i < strlen($str); ++$i) {
+        $stream = Psr7\Utils::streamFor(\quoted_printable_encode($str));
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $qpStream = new QuotedPrintableStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
-                $this->assertSame(substr($str, $j, $i), $qpStream->read($i), "Read $j failed at $i step");
+            for ($j = 0; $j < \strlen($str); $j += $i) {
+                $this->assertSame(\substr($str, $j, $i), $qpStream->read($i), "Read $j failed at $i step");
             }
-            $this->assertSame(strlen($str), $qpStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $qpStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testReadContents()
+    public function testReadContents() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -46,15 +44,15 @@ class QuotedPrintableStreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        for ($i = 0; $i < strlen($str); ++$i) {
-            $substr = substr($str, 0, $i + 1);
-            $stream = Psr7\Utils::streamFor(quoted_printable_encode($substr));
+        for ($i = 0; $i < \strlen($str); ++$i) {
+            $substr = \substr($str, 0, $i + 1);
+            $stream = Psr7\Utils::streamFor(\quoted_printable_encode($substr));
             $qpStream = new QuotedPrintableStream($stream);
             $this->assertSame($substr, $qpStream->getContents());
         }
     }
 
-    public function testReadToEof()
+    public function testReadToEof() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -62,17 +60,17 @@ class QuotedPrintableStreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        for ($i = 0; $i < strlen($str); ++$i) {
-            $substr = substr($str, $i);
-            $stream = Psr7\Utils::streamFor(quoted_printable_encode($substr));
+        for ($i = 0; $i < \strlen($str); ++$i) {
+            $substr = \substr($str, $i);
+            $stream = Psr7\Utils::streamFor(\quoted_printable_encode($substr));
             $qpStream = new QuotedPrintableStream($stream);
             for ($j = 0; !$qpStream->eof(); ++$j) {
-                $this->assertEquals(substr($substr, $j, 1), $qpStream->read(1), "Failed reading to EOF on substr $i iteration $j");
+                $this->assertEquals(\substr($substr, $j, 1), $qpStream->read(1), "Failed reading to EOF on substr $i iteration $j");
             }
         }
     }
 
-    public function testReadIgnorableNewLineCharacters()
+    public function testReadIgnorableNewLineCharacters() : void
     {
         $str = 'J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -87,25 +85,25 @@ class QuotedPrintableStreamTest extends TestCase
             . "abriquent pour=\n\n"
             . "te la vendre une =C3=A2me vulgaire.=\n";
         $stream = Psr7\Utils::streamFor($encoded);
-        for ($i = 1; $i < strlen($str); ++$i) {
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $qpStream = new QuotedPrintableStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
-                $this->assertSame(substr($str, $j, $i), $qpStream->read($i), "Read $j failed at $i step");
+            for ($j = 0; $j < \strlen($str); $j += $i) {
+                $this->assertSame(\substr($str, $j, $i), $qpStream->read($i), "Read $j failed at $i step");
             }
-            $this->assertSame(strlen($str), $qpStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $qpStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testGetSize()
+    public function testGetSize() : void
     {
         $str = 'Sweetest little pie';
-        $stream = Psr7\Utils::streamFor(quoted_printable_encode($str));
+        $stream = Psr7\Utils::streamFor(\quoted_printable_encode($str));
         $qpStream = new QuotedPrintableStream($stream);
         $this->assertNull($qpStream->getSize());
     }
 
-    public function testTell()
+    public function testTell() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -113,31 +111,31 @@ class QuotedPrintableStreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        $stream = Psr7\Utils::streamFor(quoted_printable_encode($str));
-        for ($i = 1; $i < strlen($str); ++$i) {
+        $stream = Psr7\Utils::streamFor(\quoted_printable_encode($str));
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $qpStream = new QuotedPrintableStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
+            for ($j = 0; $j < \strlen($str); $j += $i) {
                 $this->assertSame($j, $qpStream->tell(), "Tell at $j failed with $i step");
                 $qpStream->read($i);
             }
-            $this->assertSame(strlen($str), $qpStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $qpStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testBadlyEncodedStrings()
+    public function testBadlyEncodedStrings() : void
     {
-        $encoded = "=";
+        $encoded = '=';
         $stream = Psr7\Utils::streamFor($encoded);
         $qpStream = new QuotedPrintableStream($stream);
         $this->assertSame('', $qpStream->getContents());
 
-        $encoded = "= ";
+        $encoded = '= ';
         $stream = Psr7\Utils::streamFor($encoded);
         $qpStream = new QuotedPrintableStream($stream);
         $this->assertSame('= ', $qpStream->getContents());
 
-        $encoded = "=asdf";
+        $encoded = '=asdf';
         $stream = Psr7\Utils::streamFor($encoded);
         $qpStream = new QuotedPrintableStream($stream);
         $this->assertSame('=', $qpStream->read(1));
@@ -147,50 +145,50 @@ class QuotedPrintableStreamTest extends TestCase
         $this->assertSame('f', $qpStream->read(1));
     }
 
-    public function testDecodeFile()
+    public function testDecodeFile() : void
     {
         $encoded = __DIR__ . '/../_data/blueball.qp.txt';
         $org = __DIR__ . '/../_data/blueball.png';
-        $f = fopen($encoded, 'r');
+        $f = \fopen($encoded, 'r');
 
         $stream = new QuotedPrintableStream(Psr7\Utils::streamFor($f));
-        $this->assertSame(file_get_contents($org), $stream->getContents(), 'Decoded blueball not equal to original file');
+        $this->assertSame(\file_get_contents($org), $stream->getContents(), 'Decoded blueball not equal to original file');
     }
 
-    public function testWrite()
+    public function testWrite() : void
     {
-        $contents = str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
+        $contents = \str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
             . 'n\'est par essence qu\'un moyen, et te trompant ainsi sur la '
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é', 5);
 
-        for ($i = 1; $i < strlen($contents); ++$i) {
-            $stream = Psr7\Utils::streamFor(fopen('php://temp', 'r+'));
+        for ($i = 1; $i < \strlen($contents); ++$i) {
+            $stream = Psr7\Utils::streamFor(\fopen('php://temp', 'r+'));
             $out = new QuotedPrintableStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($contents); $j += $i) {
-                $out->write(substr($contents, $j, $i));
+            for ($j = 0; $j < \strlen($contents); $j += $i) {
+                $out->write(\substr($contents, $j, $i));
             }
             $out->close();
 
             $stream->rewind();
             $in = new QuotedPrintableStream(new NonClosingStream($stream));
-            $this->assertSame($contents, rtrim($in->getContents()));
+            $this->assertSame($contents, \rtrim($in->getContents()));
 
             $stream->rewind();
             $raw = $stream->getContents();
-            $arr = explode("\r\n", $raw);
-            $this->assertGreaterThan(0, count($arr));
-            for ($x = 0; $x < count($arr); ++$x) {
-                $this->assertLessThanOrEqual(76, strlen($arr[$x]));
+            $arr = \explode("\r\n", $raw);
+            $this->assertGreaterThan(0, \count($arr));
+            for ($x = 0; $x < \count($arr); ++$x) {
+                $this->assertLessThanOrEqual(76, \strlen($arr[$x]));
             }
         }
     }
 
-    public function testSeekUnsopported()
+    public function testSeekUnsopported() : void
     {
-        $stream = Psr7\Utils::streamFor(quoted_printable_encode('Sweetest little pie'));
+        $stream = Psr7\Utils::streamFor(\quoted_printable_encode('Sweetest little pie'));
         $test = new QuotedPrintableStream($stream);
         $this->assertFalse($test->isSeekable());
         $exceptionThrown = false;

--- a/tests/StreamDecorators/SeekingLimitStreamTest.php
+++ b/tests/StreamDecorators/SeekingLimitStreamTest.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use LegacyPHPUnit\TestCase;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Description of SeekingLimitStreamTest
@@ -13,7 +14,7 @@ use GuzzleHttp\Psr7;
  */
 class SeekingLimitStreamTest extends TestCase
 {
-    public function testReadLimits()
+    public function testReadLimits() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 3, 1);
@@ -21,7 +22,7 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertSame('his', $str);
     }
 
-    public function testReadLimitsToEnd()
+    public function testReadLimitsToEnd() : void
     {
         $stream = Psr7\Utils::streamFor('test');
         $res = new SeekingLimitStream($stream, 4, 0);
@@ -29,7 +30,7 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertSame('test', $str);
     }
 
-    public function testPosition()
+    public function testPosition() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 3, 1);
@@ -39,35 +40,35 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertSame(3, $res->tell());
     }
 
-    public function testGetSize()
+    public function testGetSize() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream);
         $this->assertSame($stream->getSize(), $res->getSize());
     }
 
-    public function testGetSizeWithLimit()
+    public function testGetSizeWithLimit() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 5);
         $this->assertSame(5, $res->getSize());
     }
 
-    public function testGetSizeWithLimitAndOffset()
+    public function testGetSizeWithLimitAndOffset() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 5, 1);
         $this->assertSame(5, $res->getSize());
     }
 
-    public function testGetSizeWithLimitBeyondSize()
+    public function testGetSizeWithLimitBeyondSize() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 5, 10);
         $this->assertSame(4, $res->getSize());
     }
 
-    public function testEof()
+    public function testEof() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 3, 1);
@@ -77,7 +78,7 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertTrue($res->eof());
     }
 
-    public function testEofWithStreamAtEnd()
+    public function testEofWithStreamAtEnd() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $stream->getContents();
@@ -89,7 +90,7 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertTrue($res->eof());
     }
 
-    public function testEofWithNoLimit()
+    public function testEofWithNoLimit() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $stream->getContents();
@@ -101,7 +102,7 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertTrue($res->eof());
     }
 
-    public function testEofWithNoLimitAndOffset()
+    public function testEofWithNoLimitAndOffset() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $stream->getContents();
@@ -113,7 +114,7 @@ class SeekingLimitStreamTest extends TestCase
         $this->assertTrue($res->eof());
     }
 
-    public function testSeek()
+    public function testSeek() : void
     {
         $stream = Psr7\Utils::streamFor('This is a test');
         $res = new SeekingLimitStream($stream, 3, 1);

--- a/tests/StreamDecorators/UUStreamTest.php
+++ b/tests/StreamDecorators/UUStreamTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace ZBateson\StreamDecorators;
 
-use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\StreamWrapper;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
@@ -15,47 +15,47 @@ use RuntimeException;
  */
 class UUStreamTest extends TestCase
 {
-    public function testReadAndRewind()
+    public function testReadAndRewind() : void
     {
-        $str = str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
+        $str = \str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
             . 'n\'est par essence qu\'un moyen, et te trompant ainsi sur la '
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é', 10);
-        $stream = Psr7\Utils::streamFor(convert_uuencode($str));
-        for ($i = 1; $i < strlen($str); ++$i) {
+        $stream = Psr7\Utils::streamFor(\convert_uuencode($str));
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $uuStream = new UUStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
-                $this->assertSame(substr($str, $j, $i), $uuStream->read($i), "Read $j failed at $i step");
+            for ($j = 0; $j < \strlen($str); $j += $i) {
+                $this->assertSame(\substr($str, $j, $i), $uuStream->read($i), "Read $j failed at $i step");
             }
-            $this->assertSame(strlen($str), $uuStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $uuStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testReadWithCrLf()
+    public function testReadWithCrLf() : void
     {
-        $str = str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
+        $str = \str_repeat('é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
             . 'n\'est par essence qu\'un moyen, et te trompant ainsi sur la '
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é', 10);
-        $encoded = preg_replace('/([^\r]?)\n/', "$1\r\n", convert_uuencode($str));
+        $encoded = \preg_replace('/([^\r]?)\n/', "$1\r\n", \convert_uuencode($str));
 
         $stream = Psr7\Utils::streamFor($encoded);
-        for ($i = 1; $i < strlen($str); ++$i) {
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $uuStream = new UUStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
-                $this->assertSame(substr($str, $j, $i), $uuStream->read($i), "Read $j failed at $i step");
+            for ($j = 0; $j < \strlen($str); $j += $i) {
+                $this->assertSame(\substr($str, $j, $i), $uuStream->read($i), "Read $j failed at $i step");
             }
-            $this->assertSame(strlen($str), $uuStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $uuStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testReadContents()
+    public function testReadContents() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -63,15 +63,15 @@ class UUStreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        for ($i = 0; $i < strlen($str); ++$i) {
-            $substr = substr($str, 0, $i + 1);
-            $stream = Psr7\Utils::streamFor(convert_uuencode($substr));
+        for ($i = 0; $i < \strlen($str); ++$i) {
+            $substr = \substr($str, 0, $i + 1);
+            $stream = Psr7\Utils::streamFor(\convert_uuencode($substr));
             $uuStream = new UUStream($stream);
             $this->assertSame($substr, $uuStream->getContents());
         }
     }
 
-    public function testReadToEof()
+    public function testReadToEof() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -79,24 +79,24 @@ class UUStreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        for ($i = 0; $i < strlen($str); ++$i) {
-            $stream = Psr7\Utils::streamFor(convert_uuencode(substr($str, $i)));
+        for ($i = 0; $i < \strlen($str); ++$i) {
+            $stream = Psr7\Utils::streamFor(\convert_uuencode(\substr($str, $i)));
             $uuStream = new UUStream($stream);
             for ($j = $i; !$uuStream->eof(); ++$j) {
-                $this->assertEquals(substr($str, $j, 1), $uuStream->read(1), "Failed reading to EOF on substr $i iteration $j");
+                $this->assertEquals(\substr($str, $j, 1), $uuStream->read(1), "Failed reading to EOF on substr $i iteration $j");
             }
         }
     }
 
-    public function testGetSize()
+    public function testGetSize() : void
     {
         $str = 'Sweetest little pie';
-        $stream = Psr7\Utils::streamFor(quoted_printable_encode($str));
+        $stream = Psr7\Utils::streamFor(\quoted_printable_encode($str));
         $uuStream = new UUStream($stream);
         $this->assertNull($uuStream->getSize());
     }
 
-    public function testTell()
+    public function testTell() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -105,21 +105,21 @@ class UUStreamTest extends TestCase
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
 
-        $stream = Psr7\Utils::streamFor(convert_uuencode($str));
-        for ($i = 1; $i < strlen($str); ++$i) {
+        $stream = Psr7\Utils::streamFor(\convert_uuencode($str));
+        for ($i = 1; $i < \strlen($str); ++$i) {
             $stream->rewind();
             $uuStream = new UUStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
+            for ($j = 0; $j < \strlen($str); $j += $i) {
                 $this->assertSame($j, $uuStream->tell(), "Tell at $j failed with $i step");
                 $uuStream->read($i);
             }
-            $this->assertSame(strlen($str), $uuStream->tell(), "Final tell failed with $i step");
+            $this->assertSame(\strlen($str), $uuStream->tell(), "Final tell failed with $i step");
         }
     }
 
-    public function testSeekUnsopported()
+    public function testSeekUnsopported() : void
     {
-        $stream = Psr7\Utils::streamFor(quoted_printable_encode('Sweetest little pie'));
+        $stream = Psr7\Utils::streamFor(\quoted_printable_encode('Sweetest little pie'));
         $test = new UUStream($stream);
         $this->assertFalse($test->isSeekable());
         $exceptionThrown = false;
@@ -131,7 +131,7 @@ class UUStreamTest extends TestCase
         $this->assertTrue($exceptionThrown);
     }
 
-    public function testReadWithBeginAndEnd()
+    public function testReadWithBeginAndEnd() : void
     {
         $str = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -139,11 +139,11 @@ class UUStreamTest extends TestCase
             . 'route à suivre les voilà bientôt qui te dégradent, car si leur '
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
-        $str = str_repeat($str, 10);
-        for ($i = 0; $i < strlen($str); ++$i) {
+        $str = \str_repeat($str, 10);
+        for ($i = 0; $i < \strlen($str); ++$i) {
 
-            $substr = substr($str, 0, $i + 1);
-            $encoded = convert_uuencode($substr);
+            $substr = \substr($str, 0, $i + 1);
+            $encoded = \convert_uuencode($substr);
             $encoded = "begin 666 devil.txt\r\n\r\n" . $encoded . "\r\nend\r\n";
 
             $stream = Psr7\Utils::streamFor($encoded);
@@ -152,32 +152,32 @@ class UUStreamTest extends TestCase
         }
     }
 
-    public function testDecodeFile()
+    public function testDecodeFile() : void
     {
         $encoded = __DIR__ . '/../_data/blueball.uu.txt';
         $org = __DIR__ . '/../_data/blueball.png';
-        $stream = new UUStream(Psr7\Utils::streamFor(fopen($encoded, 'r')));
-        $this->assertSame(file_get_contents($org), $stream->getContents(), 'Decoded blueball not equal to original file');
+        $stream = new UUStream(Psr7\Utils::streamFor(\fopen($encoded, 'r')));
+        $this->assertSame(\file_get_contents($org), $stream->getContents(), 'Decoded blueball not equal to original file');
     }
 
-    public function testDecodeFileWithSpaces()
+    public function testDecodeFileWithSpaces() : void
     {
         $encoded = __DIR__ . '/../_data/blueball-2.uu.txt';
         $org = __DIR__ . '/../_data/blueball.png';
-        $stream = new UUStream(Psr7\Utils::streamFor(fopen($encoded, 'r')));
-        $this->assertSame(file_get_contents($org), $stream->getContents(), 'Decoded blueball not equal to original file');
+        $stream = new UUStream(Psr7\Utils::streamFor(\fopen($encoded, 'r')));
+        $this->assertSame(\file_get_contents($org), $stream->getContents(), 'Decoded blueball not equal to original file');
     }
 
-    public function testWrite()
+    public function testWrite() : void
     {
         $org = __DIR__ . '/../_data/blueball.png';
-        $contents = file_get_contents($org);
+        $contents = \file_get_contents($org);
 
-        for ($i = 1; $i < strlen($contents); ++$i) {
-            $stream = Psr7\Utils::streamFor(fopen('php://temp', 'r+'));
+        for ($i = 1; $i < \strlen($contents); ++$i) {
+            $stream = Psr7\Utils::streamFor(\fopen('php://temp', 'r+'));
             $out = new UUStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($contents); $j += $i) {
-                $out->write(substr($contents, $j, $i));
+            for ($j = 0; $j < \strlen($contents); $j += $i) {
+                $out->write(\substr($contents, $j, $i));
             }
             $out->close();
 
@@ -188,15 +188,15 @@ class UUStreamTest extends TestCase
 
             $stream->rewind();
             $raw = $stream->getContents();
-            $arr = explode("\r\n", $raw);
-            $this->assertGreaterThan(0, count($arr));
-            for ($x = 0; $x < count($arr); ++$x) {
-                $this->assertLessThanOrEqual(61, strlen($arr[$x]));
+            $arr = \explode("\r\n", $raw);
+            $this->assertGreaterThan(0, \count($arr));
+            for ($x = 0; $x < \count($arr); ++$x) {
+                $this->assertLessThanOrEqual(61, \strlen($arr[$x]));
             }
         }
     }
 
-    public function testWriteDifferentContentLengths()
+    public function testWriteDifferentContentLengths() : void
     {
         $contents = 'é J\'interdis aux marchands de vanter trop leur marchandises. Car '
             . 'ils se font vite pédagogues et t\'enseignent comme but ce qui '
@@ -205,12 +205,12 @@ class UUStreamTest extends TestCase
             . 'musique est vulgaire ils te fabriquent pour te la vendre une âme '
             . 'vulgaire.é';
 
-        for ($i = 1; $i < strlen($contents); ++$i) {
-            $str = substr($contents, 0, strlen($contents) - $i);
-            $stream = Psr7\Utils::streamFor(fopen('php://temp', 'r+'));
+        for ($i = 1; $i < \strlen($contents); ++$i) {
+            $str = \substr($contents, 0, \strlen($contents) - $i);
+            $stream = Psr7\Utils::streamFor(\fopen('php://temp', 'r+'));
             $out = new UUStream(new NonClosingStream($stream));
-            for ($j = 0; $j < strlen($str); $j += $i) {
-                $out->write(substr($str, $j, $i));
+            for ($j = 0; $j < \strlen($str); $j += $i) {
+                $out->write(\substr($str, $j, $i));
             }
             $out->close();
 
@@ -220,10 +220,10 @@ class UUStreamTest extends TestCase
             $stream->rewind();
 
             $raw = $stream->getContents();
-            $arr = explode("\r\n", $raw);
-            $this->assertGreaterThan(0, count($arr));
-            for ($x = 0; $x < count($arr); ++$x) {
-                $this->assertLessThanOrEqual(61, strlen($arr[$x]));
+            $arr = \explode("\r\n", $raw);
+            $this->assertGreaterThan(0, \count($arr));
+            for ($x = 0; $x < \count($arr); ++$x) {
+                $this->assertLessThanOrEqual(61, \strlen($arr[$x]));
             }
         }
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+require_once \dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
Changes include:
* Add scalars to method parameters where ever possible.
* Add return types where ever possible.
* Upgrade to PHPUnit 7 or higher and remove LegacyPHPUnit package
* Update readme.md to reflect PHP version support
* Update github actions to support only PHP 7.1 and higher.
* Added PHPStan to level 6 for src and tests directories.
* Ran PHP-CS-Fixer on src and tests directories.
* Fixed code for testing read method to test against bool, since read always returns string.
* Removed useless comments `@param int $length`, but kept `@param int $length number of bytes to read`.
* Used @inheritDoc where is made sense.