### PR TITLE
Update to new Psr\Http\Message\StreamInterface spec

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1]
+        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require zbateson/stream-decorators
 
 ## Requirements
 
-StreamDecorators requires PHP 7.1 or newer.  Tested on PHP 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
+StreamDecorators requires PHP 7.2 or newer.  Tested on PHP 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "guzzlehttp/psr7": "^1.9 | ^2.0",
         "zbateson/mb-wrapper": "^1.0.0"
     },

--- a/src/Base64Stream.php
+++ b/src/Base64Stream.php
@@ -92,13 +92,9 @@ class Base64Stream implements StreamInterface
     /**
      * Not implemented (yet).
      *
-     * Seek position can be calculated.
-     *
-     * @param int $offset
-     * @param int $whence
      * @throws RuntimeException
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET) : void
     {
         throw new RuntimeException('Cannot seek a Base64Stream');
     }
@@ -144,11 +140,8 @@ class Base64Stream implements StreamInterface
      *
      * Note that reading and writing to the same stream may result in wrongly
      * encoded data and is not supported.
-     *
-     * @param int $length
-     * @return string
      */
-    public function read($length)
+    public function read(int $length) : string
     {
         // let Guzzle decide what to do.
         if ($length <= 0 || $this->eof()) {

--- a/src/CharsetStream.php
+++ b/src/CharsetStream.php
@@ -93,11 +93,9 @@ class CharsetStream implements StreamInterface
     /**
      * Not supported.
      *
-     * @param int $offset
-     * @param int $whence
      * @throws RuntimeException
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET) : void
     {
         throw new RuntimeException('Cannot seek a CharsetStream');
     }
@@ -142,11 +140,8 @@ class CharsetStream implements StreamInterface
     /**
      * Reads up to $length decoded chars from the underlying stream and returns
      * them after converting to the target string charset.
-     *
-     * @param int $length
-     * @return string
      */
-    public function read($length)
+    public function read(int $length) : string
     {
         // let Guzzle decide what to do.
         if ($length <= 0 || $this->eof()) {

--- a/src/PregReplaceFilterStream.php
+++ b/src/PregReplaceFilterStream.php
@@ -63,11 +63,9 @@ class PregReplaceFilterStream implements StreamInterface
     /**
      * Not supported by PregReplaceFilterStream
      *
-     * @param int $offset
-     * @param int $whence
      * @throws RuntimeException
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET) : void
     {
         throw new RuntimeException('Cannot seek a PregReplaceFilterStream');
     }
@@ -99,11 +97,8 @@ class PregReplaceFilterStream implements StreamInterface
     /**
      * Reads from the underlying stream, filters it and returns up to $length
      * bytes.
-     *
-     * @param int $length
-     * @return string
      */
-    public function read($length)
+    public function read(int $length) : string
     {
         $this->fillBuffer($length);
         return $this->buffer->read($length);

--- a/src/QuotedPrintableStream.php
+++ b/src/QuotedPrintableStream.php
@@ -57,11 +57,9 @@ class QuotedPrintableStream implements StreamInterface
     /**
      * Not supported.
      *
-     * @param int $offset
-     * @param int $whence
      * @throws RuntimeException
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET) : void
     {
         throw new RuntimeException('Cannot seek a QuotedPrintableStream');
     }
@@ -138,8 +136,6 @@ class QuotedPrintableStream implements StreamInterface
     /**
      * Reads up to $length decoded bytes from the underlying quoted-printable
      * encoded stream and returns them.
-     *
-     * @param int $length
      */
     public function read($length) : string
     {

--- a/src/SeekingLimitStream.php
+++ b/src/SeekingLimitStream.php
@@ -119,11 +119,8 @@ class SeekingLimitStream implements StreamInterface
      * For SeekingLimitStream, no actual seek is performed on the underlying
      * wrapped stream.  Instead, an internal pointer is set, and the stream is
      * 'seeked' on read operations
-     *
-     * @param int $offset
-     * @param int $whence
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET) : void
     {
         $pos = $offset;
         switch ($whence) {
@@ -176,11 +173,8 @@ class SeekingLimitStream implements StreamInterface
      * Reads from the underlying stream after seeking to the position within the
      * bounds set for this limited stream.  After reading, the wrapped stream is
      * 'seeked' back to its position prior to the call to read().
-     *
-     * @param int $length
-     * @return string
      */
-    public function read($length)
+    public function read(int $length) : string
     {
         $pos = $this->stream->tell();
         $ret = $this->seekAndRead($length);

--- a/src/UUStream.php
+++ b/src/UUStream.php
@@ -88,11 +88,9 @@ class UUStream implements StreamInterface
     /**
      * Not supported.
      *
-     * @param int $offset
-     * @param int $whence
      * @throws RuntimeException
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET) : void
     {
         throw new RuntimeException('Cannot seek a UUStream');
     }
@@ -173,8 +171,6 @@ class UUStream implements StreamInterface
 
     /**
      * Attempts to read $length bytes after decoding them, and returns them.
-     *
-     * @param int $length
      */
     public function read($length) : string
     {


### PR DESCRIPTION
New Psr\Http\Message\StreamInterface breaks the code. Apparently this broke 2023-04-18 for my [PHPFUI](http://www.phpfui.com) site which updates nightly.  I suspect it was caused by a GuzzleHttp dependency that finally allowed my site to be upgraded to the latest StreamInterface.

The issue is now PHP 7.1 is broken.  But at this point I think it is worth dropping 7.1 support.  There is absolutely no reason for anyone to be on 7.1, or they can lock in an old version.

I did not include that in the PR, but happy to do so.