### PR TITLE
Change text in php source to comment

### DIFF
--- a/PhpCsFixer.php
+++ b/PhpCsFixer.php
@@ -1,5 +1,5 @@
 <?php
-see vendor/zbateson/mb-wrapper/PhpCsFixer.php master version
+// see vendor/zbateson/mb-wrapper/PhpCsFixer.php master version
 
 
 


### PR DESCRIPTION
The `PhpCsFixer.php` is a php file and contains text that cannot be parsed by a php interpreter. This leads to errors when checking or using opcache.

Since it is comment the text can be changed to a real command, which makes this file a valid php file (and still keep the info).