### PR TITLE
Allow Guzzle PSR-7 v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "guzzlehttp/psr7": "^2.5",
+        "guzzlehttp/psr7": "^2.5 || ^3.0",
         "zbateson/mb-wrapper": "^2.0 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

- Allow `guzzlehttp/psr7` 2.x and 3.x.
- Preserve support for the previously supported 2.x releases.

No source changes are required because the existing stream decorators use APIs available in both supported major versions.